### PR TITLE
色の設定

### DIFF
--- a/src/sass/setting/_variables.scss
+++ b/src/sass/setting/_variables.scss
@@ -1,6 +1,11 @@
 // 色
-$background: #fff; // 背景
-$text-color: #333; // テキスト色
+$background: #111111; // 背景
+$gray: #333; // テキスト色(テキストがwhiteの時は背景色)
+$white: #fff;
+$yellow:#FFEA2E; //カテゴリとホバー時のアンダーライン
+$contact-bg:#3D3D3D; //お問い合わせの背景色
+$english-yellow:#F9F871; //セクションタイトルの英字
+$new-orange:#FFBA6A; //ブログカードのNEW
 
 // マウスホバー
 $opacity: 0.7; // 透過度


### PR DESCRIPTION
scss>setting>variables内の色を以下のように変更・追加しています。
漏れがありましたら申し訳ございません。

＜注＞
$background:#fff➡︎**#111111**
※白を$backgoundで呼び出している場合、色が変わります。

$**text-color**:#333;➡︎$**gray**:#333　
テキスト以外に背景色として使われている部分もあったため、$grayとしました。

// 色
$background: #111111; // 背景
$gray: #333; // テキスト色(テキストがwhiteの時は背景色)
$white: #fff;
$yellow:#FFEA2E; //カテゴリとホバー時のアンダーライン

以下3色は局所的な色ですが、一応設定しました。
$contact-bg:#3D3D3D; //お問い合わせの背景色
$english-yellow:#F9F871; //セクションタイトルの英字
$new-orange:#FFBA6A; //ブログカードのNEW