### PR TITLE
事業内容ページpc版ピクパ

### DIFF
--- a/src/sass/object/component/_c-pc-nav.scss
+++ b/src/sass/object/component/_c-pc-nav.scss
@@ -1,7 +1,7 @@
 .c-pc-nav{
   display:none;
 
-  @include mq("pc"){
+  @include mq("tab"){
     display: flex;
   }
 }

--- a/src/sass/object/project/_p-header.scss
+++ b/src/sass/object/project/_p-header.scss
@@ -12,7 +12,7 @@
   align-items: center;
   padding:rem(2) rem(22);
 
-  @include mq("pc") {
+  @include mq("tab") {
     padding:0 0 0 rem(33);
   }
 }
@@ -24,7 +24,7 @@
 .p-header__logo img{
   width:rem(70);
 
-  @include mq("pc") {
+  @include mq("tab") {
   width:rem(94);
   }
 }

--- a/src/sass/object/project/_p-media.scss
+++ b/src/sass/object/project/_p-media.scss
@@ -28,7 +28,7 @@
     max-width: rem(510);
 
     @include mq(tab){
-        width: 46%;
+        width: 48%;
 
     }
 }

--- a/src/sass/object/project/_p-sp-openbtn.scss
+++ b/src/sass/object/project/_p-sp-openbtn.scss
@@ -3,7 +3,7 @@
   width:rem(24);
   height:rem(50);
 
-  @include mq("pc"){
+  @include mq("tab"){
     display:none;
   }
 }

--- a/src/sass/object/project/_p-sub-content.scss
+++ b/src/sass/object/project/_p-sub-content.scss
@@ -6,6 +6,8 @@
 
     @include mq(tab){
         font-size: rem(25);
+        margin-top: rem(60);
+
     }
 
 }
@@ -18,6 +20,7 @@
     @include mq(tab){
         text-align: center;
         line-height: (35 / 16);
+        letter-spacing: 0.12em;
 
     }
 }
@@ -29,13 +32,18 @@
 
 .p-sub-content__items{
     margin-top: rem(45);
+
+    @include mq(tab){
+        margin-top: rem(147);
+
+    }
 }
 
 .p-sub-content__item{
     margin-top: rem(86);
 
     @include mq(tab){
-        margin-top: (104);
+        margin-top: rem(100);
     }
 }
 
@@ -43,17 +51,23 @@
     margin-top: rem(-18);
 
     @include mq(tab){
-        margin-top: (104);
+        margin-top: rem(104);
     }
 }
 
+.p-sub-content__item:nth-child(3) .p-media__title{
+    @include mq(tab){
+        margin-top: 0;
+    }
+
+}
 
 
 .p-sub-content__inquiry{
     margin-top: rem(160);
 
-    @include mq(tab){
-        margin-top: rem(202);
+    // @include mq(tab){
+    //     margin-top: rem(202);
 
-    }
+    // }
 }

--- a/src/sass/object/project/_p-sub-mv.scss
+++ b/src/sass/object/project/_p-sub-mv.scss
@@ -4,7 +4,7 @@
  position: relative;
  
  @include mq(tab) {
-   height: ren(370);
+   height: rem(370);
 
  }
 }


### PR DESCRIPTION
・事業内容ページPC版のピクパに係る修正
・下層ページのメインビジュアルのheightが　ren(370) になっていたので、rem(370)に修正させていただきました（_p-sub-mv.scssファイル）。
・ヘッダーのブレイクポインとを1100pxから768pxに修正